### PR TITLE
Fixed contains

### DIFF
--- a/box.py
+++ b/box.py
@@ -377,7 +377,7 @@ class Box(dict):
         return list(items)
 
     def __contains__(self, item):
-        return dict.__contains__(self, item) or hasattr(self, item)
+        return dict.__contains__(self, item)
 
     def copy(self):
         return self.__class__(super(self.__class__, self).copy())


### PR DESCRIPTION
Current behavior of `__contains__` function is not correct when `default_box=True`. It always returns `True`. 